### PR TITLE
allow wildcards in domain names

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,9 +17,18 @@ blacklistRenewal: 1440
 blacklistEverything: false
 
 # Domain names to be resolved upstream, even if they are blacklisted
+# Domains in blacklist and whitelist can begin with wildcard followed by star:
+# Pattern "*.example.com" allows all of the following:
+# - example.com
+# - subdoman.example.com
+# - deep.subdomain.example.com
+#
+# The star can only appear as a prefix and must be immediately followed by
+# a dot. You must use quotes in yaml to use the wildcard
 whitelist:
   - googleadservices.com
   - iadsdk.apple.com
+  - "*.google.com"
 
 # Optional names to be resolved to specific IP addresses
 local:

--- a/src/blacklist_test.go
+++ b/src/blacklist_test.go
@@ -6,6 +6,16 @@ import (
 	"github.com/miekg/dns"
 )
 
+func assertWhitelisted(t *testing.T, domain string, expected bool) {
+	result := isWhitelisted(domain)
+	checkTestBool(t, expected, result)
+}
+
+func assertBlacklisted(t *testing.T, domain string, expected bool) {
+	result := isBlacklisted(domain)
+	checkTestBool(t, expected, result)
+}
+
 func TestBlacklistSuccess(t *testing.T) {
 	res, err := queryBlacklist("googleads.g.doubleclick.net.", dns.TypeA)
 	checkTestBool(t, true, err == nil)
@@ -17,4 +27,32 @@ func TestBlacklistNonExistent(t *testing.T) {
 	res, err := queryBlacklist("www.apple.com.", dns.TypeA)
 	checkTestBool(t, false, err == nil)
 	checkTestBool(t, true, res == nil)
+}
+
+func TestWildcardWhitelisted(t *testing.T) {
+	// We'll implement our test by temporarily changing the global state
+	originalWhitelist := whitelistRecords
+	whitelistRecords = []string{"*.google.com"}
+	defer func() { whitelistRecords = originalWhitelist }()
+
+	assertWhitelisted(t, "mail.google.com", true)
+	assertWhitelisted(t, "google.com", true)
+	assertWhitelisted(t, "deep.deep.google.com", true)
+	assertWhitelisted(t, "google.org", false)
+}
+
+func TestWildcardBlacklisted(t *testing.T) {
+	// Set configuration to blacklist everything
+	originalConfig := ConfigInstance
+	ConfigInstance = &Config{BlacklistEverything: false}
+	defer func() { ConfigInstance = originalConfig }()
+
+	// Test with specific blacklist entries containing wildcards
+	originalBlacklist := blacklistRecords
+	blacklistRecords = []string{"*.bad-domain.com"}
+	defer func() { blacklistRecords = originalBlacklist }()
+	assertBlacklisted(t, "bad-domain.com", true)
+	assertBlacklisted(t, "under.bad-domain.com", true)
+	assertBlacklisted(t, "under.deep.bad-domain.com", true)
+	assertBlacklisted(t, "bing.com", false)
 }


### PR DESCRIPTION
Pattern "*.example.com" allows:
- example.com
- subdoman.example.com
- deep.subdomain.example.com

The star can only appear as a Prefix.
And must be immediately followed by
a dot. Only one star can appear.

That means the following are invalid:

- sub*.domain.com (doesn't start with "*.")
- *.*.domain.com (has more than one asterisk)
- domain*.com (doesn't start with "*." and has asterisk in wrong place)